### PR TITLE
tweak docker files

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,5 +7,4 @@ COPY package.json yarn.lock
 COPY . /app
 RUN yarn install
 
-COPY . /app
 CMD yarn start

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add yarn
 WORKDIR /app
 
 COPY package.json yarn.lock
+COPY . /app
 RUN yarn install
 
-COPY . /app
 CMD yarn start


### PR DESCRIPTION
* API

copies . to app/ twice, but just once suffices 😄 

* Front

Changes the order of copy so yarn install actually works (otherwise sshing into the image shows an empty node_modules/ folder).